### PR TITLE
compiler error fix

### DIFF
--- a/src/vnode.pas
+++ b/src/vnode.pas
@@ -1178,7 +1178,7 @@ end;
 
 { TGNodeList }
 
-procedure TGNodeList.SetItem ( aIndex : DWord ; const aItem : TNode ) ;
+procedure TGNodeList.SetItem ( aIndex : DWord ; const aItem : T ) ;
 begin
   inherited SetItem( aIndex, aItem );
 end;


### PR DESCRIPTION
I had to make this change to get everything to compile.

(I expect older versions of fpc let this slide since TGNodeList is only ever used with TNode but fpc 3.0.0 threw an error)